### PR TITLE
bugfix: forbidden requests fixed due to missing agent header

### DIFF
--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -13,7 +13,14 @@ let scheduleDataTimestamp = 0;
 
 const getApiKey = async (): Promise<string> => {
   try {
-    const res = await fetch(`${config.assetsUrl}/nhkworld/common/js/common.js`);
+    const res = await fetch(`${config.assetsUrl}/nhkworld/common/js/common.js`, {
+      headers: {
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+        'accept-language': 'en-US,en;q=0.9,ja;q=0.8',
+        'cache-control': 'no-cache',
+        'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+      }
+    });
     const text = await res.text();
     const match = text.match(/window\.nw_api_key=window\.nw_api_key\|\|"(?<apiKey>[^"]+)"/);
     const apiKey = match?.groups?.apiKey;
@@ -35,7 +42,15 @@ const getScheduleForPeriod = async (apiKey: string, start: Date, end: Date): Pro
   const endMillis = end.getTime();
 
   const res = await fetch(
-    `${config.scheduleUrl}/nhkworld/epg/v7b/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`
+    `${config.scheduleUrl}/nhkworld/epg/v7b/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`,
+    {
+      headers: {
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+        'accept-language': 'en-US,en;q=0.9,ja;q=0.8',
+        'cache-control': 'no-cache',
+        'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+      }
+    }
   );
 
   return await res.json();
@@ -62,7 +77,7 @@ export const getSchedule = async (): Promise<Array<Programme>> => {
       endDate: parseDate(item.endDate)
     }));
   } else {
-    throw new Error('Failed to retrieve schedule');
+    throw new Error('Failed to retrieve schedule $(items)');
   }
 };
 

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -7,7 +7,14 @@ export const getThumbnail = async (thumbnailUri: string): Promise<Buffer | null>
 
   logger.info(`Retrieving thumbnail: ${url}`);
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: {
+        'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+        'accept-language': 'en-US,en;q=0.9,ja;q=0.8',
+        'cache-control': 'no-cache',
+        'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+      }
+    });
     return await res.buffer();
   } catch (err) {
     logger.error('Failed to get thumbnail');


### PR DESCRIPTION
Since 19th September I had seen that the schedule download gets "forbidden" as an answer and subsequently stops.

I debugged it and found that by adding a proper user-agent header and others it would work again.

Fixed it for me.