### PR TITLE
Switch to new EPG endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options can be specified via the CLI or via a config file.
 ```
       --help                             Show help                     [boolean]
       --version                          Show version number           [boolean]
-  -a, --assets-url                       NHK assets url (for JS & thumbnails)
+  -a, --assets-url                       NHK assets url (for JS, may be deprecated)
                                     [string] [default: "https://www3.nhk.or.jp"]
   -b, --safety-buffer                    Number of extra milliseconds to record
                                          before and after scheduled airtime
@@ -78,7 +78,7 @@ Options can be specified via the CLI or via a config file.
                                                                         "debug"]
   -m, --match-pattern                    Glob pattern of desired program name
                                          (can be used multiple times)
-                                                        [array] [default: ["*"]]
+                                                        [array] [default: ["!(INFO)"]]
   -o, --time-offset                      Time offset relative to system time in
                                          milliseconds (e.g. to handle stream
                                          delays)           [number] [default: 0]
@@ -118,11 +118,12 @@ The location of the config file can be specified with the `-c` option.
 
 Match patterns use [micromatch](https://github.com/micromatch/micromatch). For example:
 
-| Description                | Pattern                          |
-| -------------------------- | -------------------------------- |
-| Match everything           | `["*"]`                          |
-| Japanology and Lunch ON!   | `["*japanology*", "*lunch*"]`    |
-| Everything except Newsline | `["!(*newsline*\|*nl bridge*)"]` |
+| Description                  | Pattern                          |
+| ---------------------------- | -------------------------------- |
+| Match everything             | `["*"]`                          |
+| Japanology and Lunch ON!     | `["*japanology*", "*lunch*"]`    |
+| Everything except Newsline   | `["!(*newsline*\|*nl bridge*)"]` |
+| Everything except NHK promos | `["!(INFO)"]`                    |
 
 ### Crop & Trim
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options can be specified via the CLI or via a config file.
 ```
       --help                             Show help                     [boolean]
       --version                          Show version number           [boolean]
-  -a, --assets-url                       NHK assets url (for JS, may be deprecated)
+  -a, --assets-url                       NHK assets url (deprecated)
                                     [string] [default: "https://www3.nhk.or.jp"]
   -b, --safety-buffer                    Number of extra milliseconds to record
                                          before and after scheduled airtime

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",
-  "scheduleUrl": "https://nwapi.nhk.jp",
+  "scheduleUrl": "https://masterpl.hls.nhkworld.jp",
   "streamUrl": "https://media-tyo.hls.nhkworld.jp/hls/w/live/o-master.m3u8",
   "threadLimit": 0,
   "timeOffset": 0,

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "logFile": "/logs/nhk-record.log",
   "logLevelConsole": "debug",
   "logLevelFile": "debug",
-  "matchPattern": ["*"],
+  "matchPattern": ["!(INFO)"],
   "minimumDuration": 240000,
   "safetyBuffer": 40000,
   "saveDir": "/recordings/",

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec su-exec $UID:$GID node lib/src/index.js -c /config.json
+exec su-exec $UID:$GID node lib/src/index.js -c /config.json --

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ const parser = yargs(process.argv.slice(2))
   })
   .option('schedule-url', {
     alias: 's',
-    describe: 'NHK schedule API url',
+    describe: 'NHK schedule API base URL',
     type: 'string',
     default: defaultConfig.scheduleUrl
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ const parser = yargs(process.argv.slice(2))
   .parserConfiguration({ 'strip-aliased': true, 'strip-dashed': true })
   .option('assets-url', {
     alias: 'a',
-    describe: 'NHK assets url (for JS & thumbnails)',
+    describe: 'NHK assets url (deprecated)',
     type: 'string',
     default: defaultConfig.assetsUrl
   })

--- a/src/definitions/schedule.d.ts
+++ b/src/definitions/schedule.d.ts
@@ -1,17 +1,26 @@
 interface ScheduleItem {
-  title: string;
-  subtitle: string;
-  content_clean: string;
-  description: string;
   seriesId: string;
   airingId: string;
-  pubDate: string;
-  endDate: string;
+  title: string;
+  episodeTitle: string;
+  description: string;
+  link: string;
   thumbnail: string;
+  firstShow: number;
+  startTime: string;
+  endTime: string;
+  endTimeReal: string;
+  extractProgram: number;
+  episodeId: string;
+  episodeThumbnailUrl: string;
+  episodeLink: string;
 }
 
 interface Schedule {
-  channel: {
-    item: Array<ScheduleItem>;
-  };
+  data: Array<ScheduleItem>;
+}
+
+interface DateTimeFormatPart {
+  type: string;
+  value: string;
 }

--- a/src/definitions/schedule.d.ts
+++ b/src/definitions/schedule.d.ts
@@ -12,7 +12,7 @@ interface ScheduleItem {
   endTimeReal: string;
   extractProgram: number;
   episodeId: string;
-  episodeThumbnailUrl: string;
+  episodeThumbnailURL: string;
   episodeLink: string;
 }
 

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -516,7 +516,7 @@ const getFfmpegPostProcessArguments = (
           ['-preset', 'veryfast'],
           ['-codec:v:0', 'libx264']
         ]
-      : ['-map', '0:v'],
+      : ['-map', '0:V'],
     ['-map', '0:a'],
     ['-codec', 'copy'],
     hasThumbnail

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -404,17 +404,16 @@ const getFfmpegCaptureArguments = (
     '-y',
     config.threadLimit > 0 ? ['-threads', `${config.threadLimit}`] : [],
     ['-i', config.streamUrl],
-    ['-ss', '00:00'], // this should throw away up to five seconds of the start of the mpegts stream that comes before the first keyframe
-    thumbnail
+    thumbnail ? ['-i', '-'] : [],
+    ['-map', '0:p:1'],
+    thumbnail 
       ? [
-          ['-i', '-'],
-          ['-map', '0:p:1'],
           ['-map', '1'],
           ['-disposition:v:1', 'attached_pic']
-        ]
+        ] 
       : [],
-    ['-t', `${durationSeconds}`],
     ['-codec', 'copy'],
+    ['-t', `${durationSeconds}`],
     ['-f', 'mp4'],
     programme.title ? ['-metadata', `show=${programme.title}`] : [],
     programme.subtitle ? ['-metadata', `title=${programme.subtitle}`] : [],

--- a/src/record.ts
+++ b/src/record.ts
@@ -233,7 +233,7 @@ export const record = async (programme: Programme): Promise<void> => {
   logger.info(`Recording ${programme.title} for ${targetSeconds} seconds`);
   const recordingStart = currDate();
   try {
-    const thumbnailData = await getThumbnail(programme.thumbnail);
+    const thumbnailData = programme.thumbnail !== '' ? await getThumbnail(programme.thumbnail) : null;
     await captureStream(path, targetSeconds, programme, thumbnailData);
 
     const recordingEnd = currDate();

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -57,7 +57,7 @@ export const getSchedule = async (): Promise<Array<Programme>> => {
     return items.map((item) => ({
       ...pick(['title', 'seriesId', 'airingId', 'description'])(item),
       subtitle: item.episodeTitle,
-      thumbnail: item.episodeThumbnailUrl || item.thumbnail,
+      thumbnail: item.episodeThumbnailURL || item.thumbnail,
       content: item.description,
       startDate: new Date(item.startTime),
       endDate: new Date(item.endTimeReal)

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -2,83 +2,69 @@ import { pick } from 'ramda';
 import config from './config';
 import { NHK_REQUEST_HEADERS } from './nhk';
 import logger from './logger';
-import { now, parseDate } from './utils';
+import { now } from './utils';
 
 const SCHEDULE_BEGIN_OFFSET = -2 * 60 * 60 * 1000;
-const SCHEDULE_END_OFFSET = 7 * 24 * 60 * 60 * 1000;
+const SCHEDULE_END_OFFSET = 2 * 24 * 60 * 60 * 1000;
 const MAX_CACHE_AGE = 60 * 60 * 1000;
 
 let scheduleData: Array<Programme> | null = null;
 let scheduleDataTimestamp = 0;
 
-const getApiKey = async (): Promise<string> => {
-  try {
-    const res = await fetch(`${config.assetsUrl}/nhkworld/common/js/common.js`, {
-      headers: NHK_REQUEST_HEADERS
-    });
+const getScheduleForPeriod = async (start: Date, end: Date): Promise<Schedule> => {
+  logger.debug(`Getting schedule data for ${start.toDateString()}`);
+  const finalSchedule = await getScheduleForDay(start);
 
-    if (!res.ok) {
-      throw new Error(
-        `Failed to fetch NHK common assets (status ${res.status} ${res.statusText})`
-      );
+  if (getApiDate(start) !== getApiDate(end)) {
+    const cursorDate = new Date(start.valueOf());
+    while (getApiDate(cursorDate) !== getApiDate(end)) {
+      cursorDate.setDate(cursorDate.getDate() + 1);
+      logger.debug(`Getting schedule data for ${cursorDate.toDateString()}`);
+      let cursorDateSchedule = await getScheduleForDay(cursorDate);
+      finalSchedule.data = finalSchedule.data.concat(cursorDateSchedule.data);
     }
-
-    const text = await res.text();
-    const match = text.match(/window\.nw_api_key=window\.nw_api_key\|\|"(?<apiKey>[^"]+)"/);
-    const apiKey = match?.groups?.apiKey;
-    if (apiKey) {
-      logger.debug(`Retrieved API key: ${apiKey}`);
-      return apiKey;
-    }
-  } catch (err) {
-    logger.error('Failed to retrieve API');
-    logger.error(err);
   }
 
-  logger.debug('Falling back to hardcoded API key');
-  return 'EJfK8jdS57GqlupFgAfAAwr573q01y6k';
-};
+  return finalSchedule;
+}
 
-const getScheduleForPeriod = async (apiKey: string, start: Date, end: Date): Promise<Schedule> => {
-  const startMillis = start.getTime();
-  const endMillis = end.getTime();
-
+const getScheduleForDay = async (day: Date): Promise<Schedule> => {
+  const scheduleEndpoint = `${config.scheduleUrl}/epg/w/${getApiDate(day)}.json`;
+  logger.debug(`Calling ${scheduleEndpoint} for data`);
   const res = await fetch(
-    `${config.scheduleUrl}/nhkworld/epg/v7b/world/s${startMillis}-e${endMillis}.json?apikey=${apiKey}`,
+    scheduleEndpoint,
     {
       headers: NHK_REQUEST_HEADERS
     }
   );
-
+  
   if (!res.ok) {
     throw new Error(`Failed to fetch NHK schedule (status ${res.status} ${res.statusText})`);
   }
-
+  
   return (await res.json()) as Schedule;
-};
+}
 
 export const getSchedule = async (): Promise<Array<Programme>> => {
-  const apiKey = await getApiKey();
-
-  if (!apiKey) {
-    throw new Error('Unable to retrieve API key');
-  }
-
   const start = new Date(now() + SCHEDULE_BEGIN_OFFSET);
   const end = new Date(now() + SCHEDULE_END_OFFSET);
+  logger.debug(`Getting schedule data from ${start.toDateString()} to ${end.toDateString()}`);
 
-  const rawSchedule = await getScheduleForPeriod(apiKey, start, end);
-  const items = rawSchedule?.channel?.item;
+  const rawSchedule = await getScheduleForPeriod(start, end);
+  const items = rawSchedule?.data;
 
   if (items?.length) {
-    return items.map((item) => ({
-      ...pick(['title', 'subtitle', 'seriesId', 'airingId', 'description', 'thumbnail'])(item),
-      content: item.content_clean,
-      startDate: parseDate(item.pubDate),
-      endDate: parseDate(item.endDate)
-    }));
+    return items
+      .map((item) => ({
+        ...pick(['title', 'seriesId', 'airingId', 'description'])(item),
+        subtitle: item.episodeTitle,
+        thumbnail: item.episodeThumbnailUrl || item.thumbnail,
+        content: item.description,
+        startDate: new Date(item.startTime),
+        endDate: new Date(item.endTimeReal)
+      }));
   } else {
-    throw new Error('Failed to retrieve schedule (missing items array)');
+      throw new Error('Failed to retrieve schedule (missing items array)');
   }
 };
 
@@ -118,3 +104,19 @@ export const getCurrentProgramme = async (): Promise<Programme | undefined> => {
 
   return programme;
 };
+
+const getApiDate = (day: Date): string => {
+  // each day contains a 24-hour period in JST (UTC+9)
+  const tzFormat = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  });
+  const dateParts = tzFormat.formatToParts(day);
+  return `${getDatePart('year', dateParts)}${getDatePart('month', dateParts)}${getDatePart('day', dateParts)}`;
+}
+
+const getDatePart = (part: string, dateParts: Array<DateTimeFormatPart>): string => {
+  return dateParts.find((element) => element.type === part).value;
+}

--- a/src/thumbnail.ts
+++ b/src/thumbnail.ts
@@ -3,7 +3,7 @@ import { NHK_REQUEST_HEADERS } from './nhk';
 import logger from './logger';
 
 export const getThumbnail = async (thumbnailUri: string): Promise<Buffer | null> => {
-  const url = `${config.assetsUrl}${thumbnailUri}`;
+  const url = `${thumbnailUri}`;
 
   logger.info(`Retrieving thumbnail: ${url}`);
   try {


### PR DESCRIPTION
Not necessary yet, but I assume with the recent stream change that the old EPG api will be going away soon. When that happens, we'll need this PR.

- Switch to new EPG URL/JSON structure
- The new EPG includes separate timeslot items for promo breaks; exclude these by default in the config, but allow people to get them if they want
- Reduce lookahead for EPG requests to two days in the future (new API only returns one day's worth of items at a time, don't hammer it)
- With the EPG returning full URLs for thumbnails and the key endpoint no longer being necessary, `assetsUrl` no longer has a purpose; deprecating for now but could remove it in the future, assuming the key requirement doesn't come back.